### PR TITLE
feat: delete backend data when HTTP session expires

### DIFF
--- a/azure-kit-starter/src/main/java/com/vaadin/azure/starter/sessiontracker/backend/BackendConnector.java
+++ b/azure-kit-starter/src/main/java/com/vaadin/azure/starter/sessiontracker/backend/BackendConnector.java
@@ -5,6 +5,8 @@ public interface BackendConnector {
 
     SessionInfo getSession(String clusterKey);
 
+    void deleteSession(String clusterKey);
+
     void markSerializationStarted(String clusterKey);
 
     void markSerializationComplete(String clusterKey);

--- a/azure-kit-starter/src/main/java/com/vaadin/azure/starter/sessiontracker/backend/RedisConnector.java
+++ b/azure-kit-starter/src/main/java/com/vaadin/azure/starter/sessiontracker/backend/RedisConnector.java
@@ -13,43 +13,37 @@ public class RedisConnector implements BackendConnector {
     }
 
     public void sendSession(SessionInfo sessionInfo) {
-        getLogger().info("Sending session {} to Redis", sessionInfo.getClusterKey());
-        RedisConnection connection = redisConnectionFactory.getConnection();
-        connection.set(getKey(sessionInfo.getClusterKey()),
-                sessionInfo.getData());
-        getLogger().info("Session {} sent to redis", sessionInfo.getClusterKey());
+        getLogger().info("Sending session {} to Redis",
+                sessionInfo.getClusterKey());
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            connection.set(getKey(sessionInfo.getClusterKey()),
+                    sessionInfo.getData());
+            getLogger().info("Session {} sent to redis",
+                    sessionInfo.getClusterKey());
+        }
     }
 
-    private byte[] getKey(String clusterKey) {
+    static byte[] getKey(String clusterKey) {
         return BackendUtil.b("session-" + clusterKey);
     }
 
     public SessionInfo getSession(String clusterKey) {
         getLogger().info("Requesting session for {}", clusterKey);
-        RedisConnection connection = redisConnectionFactory.getConnection();
-        if (connection.exists(getPendingKey(clusterKey))) {
-            long timeout = System.currentTimeMillis() + 5000;
-            getLogger().info("Waiting for session to be serialized before using {}", clusterKey);
-            while (connection.exists(getPendingKey(clusterKey)) && System.currentTimeMillis() < timeout) {
-                try {
-                    Thread.sleep(1);
-                } catch (InterruptedException e) {
-                }
-            }
-            if (System.currentTimeMillis() > timeout) {
-                getLogger().warn(
-                        "Gave up waiting for the serialization result. The host probably crashed during serialization");
-            }
-        }
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            waitForSerializationCompletion(clusterKey, "getting session",
+                    connection);
 
-        byte[] data = connection.get(getKey(clusterKey));
-        if (data == null) {
-            return null;
-        }
-        SessionInfo sessionInfo = new SessionInfo(clusterKey, data);
+            byte[] data = connection.get(getKey(clusterKey));
+            if (data == null) {
+                return null;
+            }
+            SessionInfo sessionInfo = new SessionInfo(clusterKey, data);
 
-        getLogger().info("Received {}", sessionInfo);
-        return sessionInfo;
+            getLogger().info("Received {}", sessionInfo);
+            return sessionInfo;
+        }
     }
 
     private static Logger getLogger() {
@@ -59,19 +53,58 @@ public class RedisConnector implements BackendConnector {
     @Override
     public void markSerializationStarted(String clusterKey) {
         getLogger().info("Marking serialization started for {}", clusterKey);
-        RedisConnection connection = redisConnectionFactory.getConnection();
-        connection.set(getPendingKey(clusterKey), BackendUtil.b("" + System.currentTimeMillis()));
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            connection.set(getPendingKey(clusterKey),
+                    BackendUtil.b("" + System.currentTimeMillis()));
+        }
     }
 
     @Override
     public void markSerializationComplete(String clusterKey) {
         getLogger().info("Marking serialization complete for {}", clusterKey);
-        RedisConnection connection = redisConnectionFactory.getConnection();
-        connection.del(getPendingKey(clusterKey));
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            connection.del(getPendingKey(clusterKey));
+        }
     }
 
-    private byte[] getPendingKey(String clusterKey) {
+    @Override
+    public void deleteSession(String clusterKey) {
+        getLogger().debug("Deleting session for {}", clusterKey);
+        try (RedisConnection connection = redisConnectionFactory
+                .getConnection()) {
+            waitForSerializationCompletion(clusterKey, "getting session",
+                    connection);
+            connection.del(getKey(clusterKey));
+            connection.del(getPendingKey(clusterKey));
+        }
+    }
+
+    static byte[] getPendingKey(String clusterKey) {
         return BackendUtil.b("pending-" + clusterKey);
     }
 
+    private void waitForSerializationCompletion(String clusterKey,
+            String action, RedisConnection connection) {
+        byte[] pendingKey = getPendingKey(clusterKey);
+        if (connection.exists(pendingKey)) {
+            long timeout = System.currentTimeMillis() + 5000;
+            getLogger().info(
+                    "Waiting for session to be serialized before {} {}", action,
+                    clusterKey);
+            while (connection.exists(pendingKey)
+                    && System.currentTimeMillis() < timeout) {
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException e) {
+                }
+            }
+            if (System.currentTimeMillis() > timeout) {
+                getLogger().warn(
+                        "Gave up waiting for the serialization result of {} before {}. The host probably crashed during serialization",
+                        clusterKey, action);
+            }
+        }
+    }
 }

--- a/azure-kit-starter/src/main/java/com/vaadin/azure/starter/sessiontracker/serialization/SerializationDebugRequestHandler.java
+++ b/azure-kit-starter/src/main/java/com/vaadin/azure/starter/sessiontracker/serialization/SerializationDebugRequestHandler.java
@@ -543,6 +543,11 @@ public class SerializationDebugRequestHandler implements RequestHandler {
             latch.countDown();
         }
 
+        @Override
+        public void deleteSession(String clusterKey) {
+            // NO-OP
+        }
+
         private SessionInfo waitForCompletion() {
             int timeout = 50000;
             try {


### PR DESCRIPTION
## Description

When the HTTP session expires and gets destroyed
the backend connector is engaged to remove the
replicate session data

Fixes #31

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
