### PR TITLE
refactor!: renamed transient field filter configuration properties

### DIFF
--- a/azure-kit-demo/src/main/resources/application.yml
+++ b/azure-kit-demo/src/main/resources/application.yml
@@ -13,7 +13,8 @@ vaadin:
       kubernetes:
         service-name: azure-kit-hazelcast-service
   serialization:
-    include-packages: com.vaadin.azure.demo
+    transients:
+      include-packages: com.vaadin.azure.demo
   devmode:
     sessionSerialization:
       enabled: true

--- a/azure-kit-starter/src/main/java/com/vaadin/azure/starter/AzureKitConfiguration.java
+++ b/azure-kit-starter/src/main/java/com/vaadin/azure/starter/AzureKitConfiguration.java
@@ -91,7 +91,7 @@ public class AzureKitConfiguration {
         @ConditionalOnMissingBean
         Predicate<Class<?>> transientInjectableFilter(
                 SerializationProperties props) {
-            return props.transientInjectableFilter();
+            return props.getTransients().transientInjectableFilter();
         }
 
         @Bean

--- a/azure-kit-starter/src/main/java/com/vaadin/azure/starter/SerializationProperties.java
+++ b/azure-kit-starter/src/main/java/com/vaadin/azure/starter/SerializationProperties.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 import static com.vaadin.azure.starter.SerializationProperties.PREFIX;
 
@@ -18,51 +19,67 @@ import static com.vaadin.azure.starter.SerializationProperties.PREFIX;
 public class SerializationProperties {
 
     public static final String PREFIX = "vaadin.serialization";
-    private final Set<String> includePackages = new HashSet<>();
-    private final Set<String> excludePackages = new HashSet<>();
+
+    @NestedConfigurationProperty
+    private final TransientsProperties transients = new TransientsProperties();
 
     /**
-     * Gets a list of packages to consider during class inspection for
-     * injectable transient fields.
+     * Gets configuration for transient fields handling during serialization.
      * 
-     * @return list of packages included in class inspection.
+     * @return configuration for transient fields handling.
      */
-    public Set<String> getIncludePackages() {
-        return includePackages;
+    public TransientsProperties getTransients() {
+        return transients;
     }
 
-    /**
-     * Gets a list of packages to exclude from class inspection for injectable
-     * transient fields.
-     *
-     * @return list of packages excluded from class inspection.
-     */
-    public Set<String> getExcludePackages() {
-        return excludePackages;
-    }
+    static class TransientsProperties {
+        private final Set<String> includePackages = new HashSet<>();
+        private final Set<String> excludePackages = new HashSet<>();
 
-    /**
-     * Gets a predicate that filters classes based on include/exclude packages
-     * configuration.
-     *
-     * An empty inclusion list means all classes are included. Exclusion rules
-     * have higher priority over inclusion rules.
-     *
-     * If no inclusion nor exclusion rules are configured all class are eligible
-     * for inspection.
-     *
-     * @return a predicate that filter classes based on configured package
-     *         rules.
-     */
-    public Predicate<Class<?>> transientInjectableFilter() {
-        if (includePackages.isEmpty() && excludePackages.isEmpty()) {
-            return type -> true;
+        /**
+         * Gets a list of packages to consider during class inspection for
+         * injectable transient fields.
+         *
+         * @return list of packages included in class inspection.
+         */
+        public Set<String> getIncludePackages() {
+            return includePackages;
         }
-        return type -> {
-            String packageName = type.getPackageName();
-            return excludePackages.stream().noneMatch(packageName::startsWith)
-                    && (includePackages.isEmpty() || includePackages.stream()
-                            .anyMatch(packageName::startsWith));
-        };
+
+        /**
+         * Gets a list of packages to exclude from class inspection for
+         * injectable transient fields.
+         *
+         * @return list of packages excluded from class inspection.
+         */
+        public Set<String> getExcludePackages() {
+            return excludePackages;
+        }
+
+        /**
+         * Gets a predicate that filters classes based on include/exclude
+         * packages configuration.
+         *
+         * An empty inclusion list means all classes are included. Exclusion
+         * rules have higher priority over inclusion rules.
+         *
+         * If no inclusion nor exclusion rules are configured all class are
+         * eligible for inspection.
+         *
+         * @return a predicate that filter classes based on configured package
+         *         rules.
+         */
+        public Predicate<Class<?>> transientInjectableFilter() {
+            if (includePackages.isEmpty() && excludePackages.isEmpty()) {
+                return type -> true;
+            }
+            return type -> {
+                String packageName = type.getPackageName();
+                return excludePackages.stream()
+                        .noneMatch(packageName::startsWith)
+                        && (includePackages.isEmpty() || includePackages
+                                .stream().anyMatch(packageName::startsWith));
+            };
+        }
     }
 }

--- a/azure-kit-starter/src/test/java/com/vaadin/azure/starter/SerializationPropertiesTest.java
+++ b/azure-kit-starter/src/test/java/com/vaadin/azure/starter/SerializationPropertiesTest.java
@@ -20,7 +20,8 @@ class SerializationPropertiesTest {
 
     @Test
     void transientInjectableFilter_excludedPackages_classIsRejected() {
-        SerializationProperties props = new SerializationProperties();
+        SerializationProperties.TransientsProperties props = new SerializationProperties()
+                .getTransients();
         props.getExcludePackages()
                 .addAll(List.of(VaadinService.class.getPackageName(),
                         TransientDescriptor.class.getPackageName()));
@@ -37,7 +38,8 @@ class SerializationPropertiesTest {
 
     @Test
     void transientInjectableFilter_includedPackages_classIsAccepted() {
-        SerializationProperties props = new SerializationProperties();
+        SerializationProperties.TransientsProperties props = new SerializationProperties()
+                .getTransients();
         props.getIncludePackages()
                 .addAll(List.of(VaadinService.class.getPackageName(),
                         TransientDescriptor.class.getPackageName()));
@@ -54,7 +56,8 @@ class SerializationPropertiesTest {
 
     @Test
     void transientInjectableFilter_mixedPackageRules_classIsAccepted() {
-        SerializationProperties props = new SerializationProperties();
+        SerializationProperties.TransientsProperties props = new SerializationProperties()
+                .getTransients();
         props.getExcludePackages()
                 .addAll(List.of(ViewAccessChecker.class.getPackageName(),
                         TransientDescriptor.class.getPackageName()));
@@ -75,7 +78,8 @@ class SerializationPropertiesTest {
 
     @Test
     void transientInjectableFilter_noRules_allClassesAreAccepted() {
-        SerializationProperties props = new SerializationProperties();
+        SerializationProperties.TransientsProperties props = new SerializationProperties()
+                .getTransients();
         Predicate<Class<?>> filter = AzureKitConfiguration.VaadinReplicatedSessionConfiguration
                 .withVaadinDefaultFilter(props.transientInjectableFilter());
 


### PR DESCRIPTION
## Description

Properties to restrict transient fields inspection are now prefixed by 'vaadin.serialization.transients'.
So now they are 'vaadin.serialization.transients.include-packages' and 'vaadin.serialization.transients.exclude-packages'.

Fixes #38

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [Z] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
