### PR TITLE
fix: avoid transient fields inspection of Java Platform classes

### DIFF
--- a/azure-kit-starter/src/test/java/com/vaadin/azure/starter/sessiontracker/serialization/SerializationDeserializationTest.java
+++ b/azure-kit-starter/src/test/java/com/vaadin/azure/starter/sessiontracker/serialization/SerializationDeserializationTest.java
@@ -1,17 +1,25 @@
 package com.vaadin.azure.starter.sessiontracker.serialization;
 
+import javax.activation.MimeType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import sun.misc.Unsafe;
 
 @ContextConfiguration(classes = TestConfig.class)
 @ExtendWith(SpringExtension.class)
@@ -76,4 +84,32 @@ class SerializationDeserializationTest {
                 .hasAllNullFieldsOrProperties();
     }
 
+    @Test
+    void serialization_defaultInjectableFilter_componentIgnored(
+            @Autowired TestConfig.CtorInjectionTarget obj) throws Exception {
+        List<Object> target = new ArrayList<>();
+        target.add(new HashMap<>());
+        target.add(obj);
+        target.add(new MimeType());
+
+        TransientHandler mockHandler = Mockito.mock(TransientHandler.class);
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        new TransientInjectableObjectOutputStream(os, mockHandler)
+                .writeWithTransients(target);
+
+        Mockito.verify(mockHandler).inspect(obj);
+        Mockito.verifyNoMoreInteractions(mockHandler);
+    }
+
+    @Test
+    void defaultInspectionFilter_rejectJavaClasses() {
+        Pattern pattern = TransientInjectableObjectOutputStream.INSPECTION_REJECTION_PATTERN;
+        Assertions.assertThat(ArrayList.class.getPackageName())
+                .matches(pattern);
+        Assertions.assertThat(MimeType.class.getPackageName()).matches(pattern);
+        Assertions.assertThat("sun.misc.Unsafe").matches(pattern); // NOSONAR
+        Assertions.assertThat("com.sun.security.auth.LdapPrincipal")
+                .matches(pattern); // NOSONAR
+    }
 }


### PR DESCRIPTION
## Description

Inspecting Java platform classes for transient fields is useless. Avoid inspection for them by default, even if a custom filter is provided.

Fixes #39

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
